### PR TITLE
Add "Signatures Yesterday" counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
         <div class="total-progress">
             <h2>Total Progress</h2>
             <p class="total-count">Loading total signature count...</p>
+            <p class="yesterday-count">Loading yesterday's signatures...</p>
             <p class="today-count">Loading today's signatures...</p>
             <p class="percentage-to-goal"></p>
             <div class="progress-bar">


### PR DESCRIPTION
I found it hard to get a feeling of how well we were doing, just looking at the number of signatures today, and wanted to easily see yesterday's signatures as a point of comparison. So I added a field that shows yesterday's signatures.

I know you haven't added a license, so I hope this is OK.

Full disclosure, I made use of an AI assistant to help me write the code, but I have read through it all, and think it generally matches the code style relatively well