### PR TITLE
Add progress bar styles beyond 300% and a diamond frame

### DIFF
--- a/StyleSheet.css
+++ b/StyleSheet.css
@@ -155,6 +155,27 @@ body {
     left: 0;
 }
 
+/* Progress bar fill for the fourth 100% */
+.progress-fourth {
+    height: 100%;
+    background-color: #00834c;
+    width: 0;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+/* Progress bar fill for the fifth 100% */
+.progress-fifth {
+    height: 100%;
+    background-color: #239fa8;
+    ;
+    width: 0;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
 .progress-divider {
     border-right: 1px solid #26292f;
 }
@@ -448,6 +469,11 @@ body {
     max-width: 500px;
     margin-top: 20px;
     border-radius: 10px;
+}
+
+.diamond-frame {
+    border: 0px solid #ccffff;
+    box-shadow: 0 0 10px #ccffff;
 }
 
 .gold-frame {

--- a/main.js
+++ b/main.js
@@ -103,6 +103,10 @@ function displayCountries(countries, showUpdateMessage = false) {
     const parentDiv = document.getElementById('myDiv');
     parentDiv.innerHTML = ''; // Clear existing content
 
+    const progressClasses = [undefined, 'progress', 'progress-second', 'progress-third', 'progress-fourth', 'progress-fifth'];
+    const maxBarPercentage = progressClasses.length * 100; // largest percentage that can be properly represented by bars
+    const maxBarIndex = progressClasses.length - 1;
+    
     // Fetch all flag URLs
     const flagPromises = countries.map(item => {
         const countryName = countryNames[item.countryCode] || item.countryCode;
@@ -296,40 +300,33 @@ function displayCountries(countries, showUpdateMessage = false) {
             const countryProgressBar = document.createElement('div');
             countryProgressBar.className = 'progress-bar';
 
-            const progressBarFill = document.createElement('div');
-            progressBarFill.className = 'progress';
-            const progressBarSecondFill = document.createElement('div');
-            progressBarSecondFill.className = 'progress-second';
-            const progressBarThirdFill = document.createElement('div');
-            progressBarThirdFill.className = 'progress-third';
-
             // Calculate the width for each layer
             const percentage = item.percentage;
-            const firstLayerWidth = Math.min(percentage, 100);
-            const secondLayerWidth = Math.min(Math.max(percentage - 100, 0), 100);
-            const thirdLayerWidth = Math.min(Math.max(percentage - 200, 0), 100);
+            const isOverflow = percentage >= maxBarPercentage;
+            const backBarIndex = isOverflow ? maxBarIndex : Math.floor(percentage / 100);
+            const frontBarIndex = isOverflow ? maxBarIndex : backBarIndex + 1;
+            const frontBarWidth = isOverflow ? 0 : percentage % 100;
 
-            progressBarFill.style.width = `${firstLayerWidth}%`;
-            progressBarSecondFill.style.width = `${secondLayerWidth}%`;
-            progressBarThirdFill.style.width = `${thirdLayerWidth}%`;
+            const progressBarBack = document.createElement('div');
+            if (backBarIndex > 0) {
+                progressBarBack.className = progressClasses[backBarIndex];
+            }
+
+            const progressBarFront = document.createElement('div');
+            progressBarFront.className = progressClasses[frontBarIndex];
+            
+            progressBarBack.style.width = `100%`;
+            progressBarFront.style.width = `${frontBarWidth}%`;
 
             // Conditionally add the border class
-            if (firstLayerWidth > 1) {
-                progressBarFill.classList.add('progress-divider');
+            if (frontBarWidth > 1) {
+                progressBarFront.classList.add('progress-divider');
             }
-            if (secondLayerWidth > 1) {
-                progressBarSecondFill.classList.add('progress-divider');
-            }
-            if (thirdLayerWidth > 1) {
-                progressBarThirdFill.classList.add('progress-divider');
-            }
-
 
             // Create a span element for the percentage text
             const percentageText = document.createElement('span');
             percentageText.className = 'percentage-text';
             percentageText.textContent = `${percentage.toLocaleString()}%`;
-
 
 
             // Create a new p element for the disclaimer
@@ -339,18 +336,17 @@ function displayCountries(countries, showUpdateMessage = false) {
 
 
             // Append the filled progress bars to the progress bar container
-            countryProgressBar.appendChild(progressBarFill);
-            countryProgressBar.appendChild(progressBarSecondFill);
-            countryProgressBar.appendChild(progressBarThirdFill);
+            countryProgressBar.appendChild(progressBarBack);
+            countryProgressBar.appendChild(progressBarFront);
 
             // Append the percentage text to the progress bar container
             countryProgressBar.appendChild(percentageText);
 
-
-
-
             // Add the correct frame based on the progress
-            if (percentage >= 300) {
+            if (percentage >= 400) {
+                div.classList.add('diamond-frame');
+            }
+            else if (percentage >= 300) {
                 div.classList.add('gold-frame');
             }
             else if (percentage >= 200) {


### PR DESCRIPTION
Addressing issue #14

Also included a general refactor to add only two progress bar layers at a time.

Here's a screenshot with simulated extra progress to showcase extra bars and the diamond frame:
![image](https://github.com/user-attachments/assets/85b7fe94-9a88-4b41-8fae-a79983b48860)

Colours may be changed if someone has a better suggestion. ^^